### PR TITLE
Add `CONFIG_CPP_NEW_INCLUDE` Flag to force use of library (Fixes #39)

### DIFF
--- a/src/platform/Platform_New.h
+++ b/src/platform/Platform_New.h
@@ -27,7 +27,12 @@
 # define NOEXCEPT throw()
 #endif
 
-#if !defined(CONFIG_CPP_NEW_ALT) && \
+#if defined(CONFIG_CPP_NEW_INCLUDE)
+# if defined(CONFIG_CPP_NEW_ALT)
+#  warning "CONFIG_CPP_NEW_ALT ignored as CONFIG_CPP_NEW_INCLUDE takes precedence"
+# endif
+# include <new>
+#elif !defined(CONFIG_CPP_NEW_ALT) && \
     (defined(__has_include) && __has_include(<new>))
 # include <new>
 #else


### PR DESCRIPTION
This PR adds a `CONFIG_CPP_NEW_INCLUDE` flag (similar to the existing `CONFIG_CPP_NEW_ALT`) which will allow for a user to force the use of the <new> library when `__has_include(<new>)` doesn't function. This flag shouldn't be needed for most use cases, but may be required for specific toolchains. 